### PR TITLE
Update apps for strict snap confinement

### DIFF
--- a/snaps/README.md
+++ b/snaps/README.md
@@ -5,9 +5,6 @@ that can leverage the Intel NPU. Building the snaps is resource intensive,
 so it is recommended to do so on a machine with a lot of cores and at least
 32 GB of RAM (16 GB will fail without a patch for the NPU UMD build configuration).
 
-As of 20 Aug 2024 these applications should be installed in devmode in order
-to access the NPU device.
-
 Note that these snaps are currently meant to be a reference for how to build
 and integrate the NPU software stack from a snap. Long term we may distribute
 the NPU software stack as a snap extension or through the content interface

--- a/snaps/openvino/README.md
+++ b/snaps/openvino/README.md
@@ -98,7 +98,7 @@ that saves or loads the model after patching the xml file.
 Additionally, because the app does not have permissions to access a user's home
 directory, a different model path must be used compared to the one used in
 the upstream Intel Jupyter notebook. A good choice for the model path is
-`/home/ubuntu/snaps/openvino/current` as this is accessible both inside and outside
+`/home/ubuntu/snap/openvino/current` as this is accessible both inside and outside
 the snap.
 
 ### iPython
@@ -124,7 +124,7 @@ To run on a CPU:
 openvino.benchmark-app -m $model_path -d CPU -hint latency
 ```
 
-To run on a CPU:
+To run on a NPU:
 
 ```
 openvino.benchmark-app -m $model_path -d NPU -hint latency

--- a/snaps/openvino/README.md
+++ b/snaps/openvino/README.md
@@ -12,8 +12,6 @@ Build the snap:
 snapcraft
 ```
 
-Install the snap (use `--devmode` if testing without NPU snap interface):
-
 ```
 sudo snap install --dangerous ./openvino_2024.3.0_amd64.snap
 ```
@@ -63,7 +61,12 @@ sudo dmesg | grep intel_vpu
 
 ## Running the applications
 
-TODO: connect snap to custom NPU snap interface
+First connect the snap to the `custom-device` interface, which enables
+access to the NPU device node on the host:
+
+```
+sudo snap connect openvino:intel-npu-plug openvino:intel-npu-slot
+```
 
 If you have not done so already, ensure the following
 are performed in oder to set up non-root access to the
@@ -91,6 +94,12 @@ and the suggested workaround until the bug is fixed. The workaround can be deplo
 after you have saved the model to OpenVINO IR format, and before you have compiled it
 with `compiled_model = core.compile_model(model, device)`. You should re-run the cell
 that saves or loads the model after patching the xml file.
+
+Additionally, because the app does not have permissions to access a user's home
+directory, a different model path must be used compared to the one used in
+the upstream Intel Jupyter notebook. A good choice for the model path is
+`/home/ubuntu/snaps/openvino/current` as this is accessible both inside and outside
+the snap.
 
 ### iPython
 
@@ -121,8 +130,10 @@ To run on a CPU:
 openvino.benchmark-app -m $model_path -d NPU -hint latency
 ```
 
-Note this app can also be invoked from an iPython session like so:
+Note this app **cannot** be invoked from an iPython session unless you are running
+in `devmode`:
 
 ```
+# This only works if the snap is installed in dev mode!
 !/snap/bin/openvino.benchmark-app...
 ```

--- a/snaps/openvino/snap/snapcraft.yaml
+++ b/snaps/openvino/snap/snapcraft.yaml
@@ -12,16 +12,41 @@ description: |
 grade: devel
 confinement: strict
 
+slots:
+  intel-npu-slot:
+    interface: custom-device
+    custom-device: intel-npu-device
+    devices:
+      - /dev/accel/accel[0-9]
+      - /dev/accel/accel[1-5][0-9]
+      - /dev/accel/accel6[0-3]
+    udev-tagging:
+      - kernel: accel[0-9]
+        subsystem: accel
+      - kernel: accel[1-5][0-9]
+        subsystem: accel
+      - kernel: accel6[0-3]
+        subsystem: accel
+
+plugs:
+  intel-npu-plug:
+    interface: custom-device
+    custom-device: intel-npu-device
+
 apps:
 
   ipython3:
     command: usr/bin/ipython3
+    plugs:
+      - intel-npu-plug
+      - network # for common tasks like downloading datasets
     environment:
       PYTHONPATH: $SNAP/usr/lib/python3/dist-packages:$SNAP/usr/python:$PYTHONPATH
       LD_LIBRARY_PATH: $SNAP/usr/runtime/lib/intel64:$SNAP/usr/runtime/3rdparty/tbb/lib:$SNAP/usr/lib/x86_64-linux-gnu/blas:$SNAP/usr/lib/x86_64-linux-gnu/lapack:$LD_LIBRARY_PATH
 
   benchmark-app:
     command: usr/bin/samples_bin/benchmark_app
+    plugs: [intel-npu-plug]
     environment:
       LD_LIBRARY_PATH: $SNAP/usr/runtime/lib/intel64:$SNAP/usr/runtime/3rdparty/tbb/lib:$LD_LIBRARY_PATH
 

--- a/snaps/openvino/snap/snapcraft.yaml
+++ b/snaps/openvino/snap/snapcraft.yaml
@@ -23,10 +23,16 @@ slots:
     udev-tagging:
       - kernel: accel[0-9]
         subsystem: accel
+        attributes:
+          vendor: "0x8086" # Intel
       - kernel: accel[1-5][0-9]
         subsystem: accel
+        attributes:
+          vendor: "0x8086" # Intel
       - kernel: accel6[0-3]
         subsystem: accel
+        attributes:
+          vendor: "0x8086" # Intel
 
 plugs:
   intel-npu-plug:

--- a/snaps/vpu-umd-test/README.md
+++ b/snaps/vpu-umd-test/README.md
@@ -12,8 +12,6 @@ Build the snap:
 snapcraft
 ```
 
-Install the snap (use `--devmode` if testing without NPU snap interface):
-
 ```
 sudo snap install --dangerous ./vpu-umd-test_1.5.1_amd64.snap
 ```
@@ -62,7 +60,12 @@ TODO: verify firmware is the expected version.
 
 ## Running the vpu-umd-test application
 
-TODO: connect snap to custom NPU snap interface
+First connect to the `custom-device` interface, which allows access the
+NPU device node on the host:
+
+```
+sudo snap connect vpu-umd-test:intel-npu-plug vpu-umd-test:intel-npu-slot
+```
 
 If you have not done so already, ensure the following
 are performed in oder to set up non-root access to the
@@ -80,17 +83,19 @@ sudo chown root:render /dev/accel/accel0
 sudo chmod g+rw /dev/accel/accel0
 ```
 
-Create input for tests:
+Create input for tests. Note that the data need to be stored in a special
+path that is accessible from inside the snap (`/home/ubuntu/snap/vpu-umd-test/current`).
 
 ```
-mkdir -p models/add_abc
-curl -o models/add_abc/add_abc.xml https://raw.githubusercontent.com/openvinotoolkit/openvino/master/src/core/tests/models/ir/add_abc.xml
-touch models/add_abc/add_abc.bin
-curl -o basic.yaml https://raw.githubusercontent.com/intel/linux-npu-driver/v1.5.1/validation/umd-test/configs/basic.yaml
+mkdir -p snap/vpu-umd-test/current/models/add_abc
+curl -o snap/vpu-umd-test/current/models/add_abc/add_abc.xml https://raw.githubusercontent.com/openvinotoolkit/openvino/master/src/core/tests/models/ir/add_abc.xml
+touch snap/vpu-umd-test/current/models/add_abc/add_abc.bin
+curl -o snap/vpu-umd-test/current/basic.yaml https://raw.githubusercontent.com/intel/linux-npu-driver/v1.5.1/validation/umd-test/configs/basic.yaml
+sed -i "s|models/|snap/vpu-umd-test/current/models/|" snap/vpu-umd-test/current/basic.yaml
 ```
 
 Finally run the application:
 
 ```
-vpu-umd-test --config=basic.yaml
+vpu-umd-test --config=snap/vpu-umd-test/current/basic.yaml
 ```

--- a/snaps/vpu-umd-test/snap/snapcraft.yaml
+++ b/snaps/vpu-umd-test/snap/snapcraft.yaml
@@ -12,10 +12,32 @@ description: |
 grade: devel
 confinement: strict
 
+slots:
+  intel-npu-slot:
+    interface: custom-device
+    custom-device: intel-npu-device
+    devices:
+      - /dev/accel/accel[0-9]
+      - /dev/accel/accel[1-5][0-9]
+      - /dev/accel/accel6[0-3]
+    udev-tagging:
+      - kernel: accel[0-9]
+        subsystem: accel
+      - kernel: accel[1-5][0-9]
+        subsystem: accel
+      - kernel: accel6[0-3]
+        subsystem: accel
+
+plugs:
+  intel-npu-plug:
+    interface: custom-device
+    custom-device: intel-npu-device
+
 apps:
 
   vpu-umd-test:
     command: usr/bin/vpu-umd-test
+    plugs: [intel-npu-plug]
 
   set-firmware-path:
     command: usr/bin/set-firmware-path

--- a/snaps/vpu-umd-test/snap/snapcraft.yaml
+++ b/snaps/vpu-umd-test/snap/snapcraft.yaml
@@ -23,10 +23,16 @@ slots:
     udev-tagging:
       - kernel: accel[0-9]
         subsystem: accel
+        attributes:
+          vendor: "0x8086" # Intel
       - kernel: accel[1-5][0-9]
         subsystem: accel
+        attributes:
+          vendor: "0x8086" # Intel
       - kernel: accel6[0-3]
         subsystem: accel
+        attributes:
+          vendor: "0x8086" # Intel
 
 plugs:
   intel-npu-plug:


### PR DESCRIPTION
Notes about NPU device nodes:

* NPU software stack scans `/dev/accel/` for char devices starting with `accel0` up to `accel63` (64 devices total). In practice generally only `/dev/accel/accel0` is present but for completeness all 64 devices are included in this PR.
* The [`custom-device`](https://snapcraft.io/docs/custom-device-interface) interface has restrictions on the use of globs and other special wildcard syntax (they need to not cause problems with app armor rules syntax), so unfortunately the 64 devices had to be expressed across three lines. Note the docs even use syntax that is not supported.