### PR TITLE
Add GIMP POC

### DIFF
--- a/snaps/gimp/README.md
+++ b/snaps/gimp/README.md
@@ -1,0 +1,55 @@
+# Instructions for building and running the snap
+
+**Important**: this snap was developed for POC purposes only and is not intended for production use. There are many "hacky" solutions used to get the snap running on the NPU properly, and ultimately we'll need better approaches for the real packaging work. The `snapcraft.yaml` is committed here to preserve the history of the POC.
+
+## Building and installing the snap
+
+Build the snap:
+
+```
+snapcraft
+```
+
+Before installing the snap, make sure to install the latest `intel-npu-driver` snap from the store:
+
+```
+sudo snap install --beta intel-npu-driver
+```
+
+Install the snap:
+
+```
+sudo snap install --dangerous ./gimp_2.99.19-dev_amd64.snap
+```
+
+**Important note**: the size of the snap is multiple GB because for now the models are being built into the snap.
+
+## Running the applications
+
+The `content` interface provides access to the NPU libs.
+
+```
+sudo snap connect gimp:npu-libs intel-npu-driver:npu-libs
+```
+
+If you have not done so already, ensure the following
+are performed in order to set up non-root access to the
+NPU device:
+
+```
+sudo usermod -a -G render $USER # log out and log back in
+```
+
+If this is your first run, or if you re-loaded the `intel_vpu` driver,
+then you'll also need to perform the following:
+
+```
+sudo chown root:render /dev/accel/accel0
+sudo chmod g+rw /dev/accel/accel0
+```
+
+Now you are ready to launch GIMP:
+
+```
+gimp
+```

--- a/snaps/gimp/patch
+++ b/snaps/gimp/patch
@@ -1,0 +1,213 @@
+diff --git a/snap/snapcraft.yaml b/snap/snapcraft.yaml
+index 7a7d07f..a2819cd 100755
+--- a/snap/snapcraft.yaml
++++ b/snap/snapcraft.yaml
+@@ -13,7 +13,6 @@ base: core24
+ compression: lzo
+ 
+ platforms:
+-  arm64:
+   amd64:
+ 
+ layout:
+@@ -32,18 +31,30 @@ slots:
+     bus: session
+     name: org.gimp.GIMP.UI
+ 
++plugs:
++  intel-npu:
++    interface: custom-device
++    custom-device: intel-npu-device
++  npu-libs:
++    interface: content
++    content: npu-libs-2404
++    target: $SNAP/usr/lib/npu-libs-2404
++    #default-provider: intel-npu-driver # must be in latest/stable channel so commenting for now
++  process-control:
++    interface: process-control
++
+ environment:
+   GI_TYPELIB_PATH: $SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gjs/girepository-1.0:$GI_TYPELIB_PATH
+-  LD_LIBRARY_PATH: $SNAP/lib:$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas
++  LD_LIBRARY_PATH: $SNAP/lib:$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/gnome-platform/usr/lib:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas:$SNAP/usr/lib/npu-libs-2404:$SNAP/usr/local/lib
+   # Ensure the gmic plugin can correctly locate the QT plugins
+   QT_PLUGIN_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/qt6/plugins
++  PYTHONPATH: $SNAP/gnome-platform/usr/lib/python3.12:$SNAP/gimpenv3/lib/python3.12/site-packages:$PYTHONPATH
+ 
+ apps:
+   gimp:
+     command: usr/bin/gimp-2.99
+     extensions: [gnome]
+     desktop: usr/share/applications/gimp.desktop
+-
+     common-id: org.gimp.GIMP
+     slots:
+       - dbus-gimp
+@@ -54,13 +65,17 @@ apps:
+       - network
+       - removable-media
+       - unity7
++      - intel-npu
++      - npu-libs
++      - process-control
+ 
+ parts:
+   babl:
+     plugin: meson
+     source: https://gitlab.gnome.org/GNOME/babl.git
+     # TODO: replace this with a tag on next release
+-    source-commit: c5f97c86224a473cc3fea231f17adef84580f2cc
++    #source-commit: c5f97c86224a473cc3fea231f17adef84580f2cc
++    source-tag: BABL_0_1_98
+     meson-parameters:
+       - --prefix=/usr
+       - --buildtype=release
+@@ -73,7 +88,8 @@ parts:
+       - babl
+     source: https://gitlab.gnome.org/GNOME/gegl.git
+     # TODO: replace this with a tag on next release
+-    source-commit: d540df2ad27c06891271d96247f915073b042a3e
++    #source-commit: d540df2ad27c06891271d96247f915073b042a3e
++    source-tag: GEGL_0_4_46
+     plugin: meson
+     meson-parameters:
+       - --prefix=/usr
+@@ -129,7 +145,8 @@ parts:
+       - gegl
+     plugin: meson
+     source: https://gitlab.gnome.org/GNOME/gimp.git
+-    source-commit: a92388c433da868c5d84b14362f7a8151d287ad7
++    #source-commit: a92388c433da868c5d84b14362f7a8151d287ad7
++    source-tag: GIMP_2_99_16
+     override-pull: |
+       # TODO: remove `craftctl default` and use this when 2.99.19 actually releases
+       #   tag="$(echo "GIMP_${SNAPCRAFT_PROJECT_VERSION}" | tr "." "_")"
+@@ -147,6 +164,13 @@ parts:
+       - -Denable-default-bin=enabled
+       - -Drelocatable-bundle=yes
+       - -Dlibunwind=true
++    override-stage: |
++      echo "python=/usr/bin/python3" >  $CRAFT_PART_INSTALL/usr/lib/x86_64-linux-gnu/gimp/2.99/interpreters/pygimp.interp
++      echo "python3=/usr/bin/python3" >>  $CRAFT_PART_INSTALL/usr/lib/x86_64-linux-gnu/gimp/2.99/interpreters/pygimp.interp
++      echo "/usr/bin/python=/usr/bin/python3" >>  $CRAFT_PART_INSTALL/usr/lib/x86_64-linux-gnu/gimp/2.99/interpreters/pygimp.interp
++      echo "/usr/bin/python3=/usr/bin/python3" >>  $CRAFT_PART_INSTALL/usr/lib/x86_64-linux-gnu/gimp/2.99/interpreters/pygimp.interp
++      echo ":Python:E::py::python3:" >>  $CRAFT_PART_INSTALL/usr/lib/x86_64-linux-gnu/gimp/2.99/interpreters/pygimp.interp
++      craftctl default
+     build-environment:
+       - BABL_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/babl-0.1
+       - GEGL_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gegl-0.4
+@@ -218,54 +242,68 @@ parts:
+       - mypaint-data
+       - poppler-data
+ 
+-  gmic:
++  openvino-plugin:
+     after: [gimp]
+     plugin: nil
+-    override-pull: |
+-      VERSION=v.3.4.2
+-      git clone -b "$VERSION" https://github.com/GreycLab/gmic.git
+-      git clone -b "$VERSION" https://github.com/GreycLab/CImg.git
+-      git clone -b "$VERSION" https://github.com/c-koi/gmic-qt.git
+-
+-      # Force this extra online fetch to happen during the pull phase.
+-      # This build takes a long time on Launchpad, and if we wait until
+-      # the build phase, by the time we get there the proxy token has
+-      # expired - so force it to happen here.
+-      wget -qO gmic/src/gmic_stdlib_community.h "https://gmic.eu/gmic_stdlib_community$(echo "${VERSION}" | tr -d "v.").h"
+-    build-environment:
+-      - QT_SELECT: qt6
++    source: https://github.com/intel/openvino-ai-plugins-gimp.git
++    source-tag: v2.99-R3.1
++    #build-environment:
++    #  - PATH: /snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
++    #  - PYTHONPATH: ""
+     build-packages:
+-      - pkg-config
+-      - qmake6-bin
+-      - qt6-base-dev
+-      - qt6-l10n-tools
+-      - qt6-tools-dev
+-      - qt6-wayland-dev
+-      - qtchooser
+-      - wget
++      - rsync
+     stage-packages:
+-      - libcurl4
+-      - libdouble-conversion3
+-      - libfftw3-bin
+-      - libffi8
+-      - libgraphicsmagick-q16-3
+-      - libgraphicsmagick++-q16-12
+-      - libjpeg-turbo8
+-      - libopencv-core406t64
+-      - libopencv-highgui406t64
+-      - libopencv-video406t64
+-      - libopenexr-3-1-30
+-      - libpng16-16
+-      - libqt6core6t64
+-      - libqt6gui6t64
+-      - libqt6network6t64
+-      - libqt6widgets6t64
+-      - qt6-wayland
++      - ocl-icd-libopencl1
++      - wget
+     override-build: |
+-      qtchooser -install qt6 "$(which qmake6)" || true
+-      make -C gmic/src CImg.h gmic_stdlib_community.h
+-      cd gmic-qt
+-      qmake HOST=gimp3
+-      make
+-      install -Dm 0755 $CRAFT_PART_BUILD/gmic-qt/gmic_gimp_qt \
+-        $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/3.0/plug-ins/gmic_gimp_qt/gmic_gimp_qt
++      set -e
++      which python3
++      python3 --version
++      python3 -m pip install --break-system-packages --user virtualenv
++      chmod +x install.sh
++      echo "1 2 3 4 0" | ./install.sh --install_models
++      mkdir -p $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/
++      cp -r $HOME/.config/GIMP/2.99/plug-ins/* $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/
++      sed -i "/self.core.set_property({'CACHE_DIR': os.path.join(model, 'cache')})/d" $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/openvino_utils/tools/openvino_common/models_ov/stable_diffusion_engine.py
++      sed -i "/try_enable_npu_turbo(device, self.core)/d" $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/openvino_utils/tools/openvino_common/models_ov/stable_diffusion_engine.py
++      sed -i 's/if "NPU" in device:/if "STOP" in device:/g' $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/openvino_utils/tools/openvino_common/models_ov/stable_diffusion_engine.py
++      sed -i 's/sd_option_cache = os.path.join(weight_path, ".."/sd_option_cache = os.path.join("."/g' $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/stable_diffusion_ov/stable_diffusion_ov.py
++      sed -i 's/os.path.join(weight_path, "..", "gimp_openvino_run_sd.json"/os.path.join(".", "gimp_openvino_run_sd.json"/g' $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/openvino_utils/tools/stable_diffusion_ov_server.py
++      sed -i 's/file_new_for_path(os.path.join(weight_path, ".."/file_new_for_path(os.path.join("."/g' $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/stable_diffusion_ov/stable_diffusion_ov.py
++      sed -i 's/cv2.imwrite(os.path.join(weight_path, ".."/cv2.imwrite(os.path.join("."/g' $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/openvino_utils/tools/stable_diffusion_ov_server.py
++      sed -i 's/DeviceEnum(supported_modes)/DeviceEnum(["CPU", "Balanced", "NPU"])/g' $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/stable_diffusion_ov/stable_diffusion_ov.py
++      sed -i 's/Power Mode/Device/g' $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/stable_diffusion_ov/stable_diffusion_ov.py
++      mkdir -p $CRAFT_PART_BUILD/mms_tmp
++      rsync -a $CRAFT_PART_BUILD/mms_tmp $CRAFT_PART_INSTALL/.
++      rsync -a /root/parts/openvino-plugin/gimpenv3 $CRAFT_PART_INSTALL/.
++      rsync -a /root/openvino-ai-plugins-gimp/weights $CRAFT_PART_INSTALL/.
++      echo "{" > $CRAFT_PART_INSTALL/weights/stable-diffusion-ov/stable-diffusion-1.5/square_int8/config.json
++      echo '      "power modes supported": "yes",' >> $CRAFT_PART_INSTALL/weights/stable-diffusion-ov/stable-diffusion-1.5/square_int8/config.json
++      echo '      "npu": ["NPU","NPU","NPU","NPU"],' >> $CRAFT_PART_INSTALL/weights/stable-diffusion-ov/stable-diffusion-1.5/square_int8/config.json
++      echo '      "balanced": ["NPU","CPU","NPU","NPU"],' >> $CRAFT_PART_INSTALL/weights/stable-diffusion-ov/stable-diffusion-1.5/square_int8/config.json
++      echo '      "cpu": ["CPU","CPU","CPU","CPU"]' >> $CRAFT_PART_INSTALL/weights/stable-diffusion-ov/stable-diffusion-1.5/square_int8/config.json
++      echo "}" >> $CRAFT_PART_INSTALL/weights/stable-diffusion-ov/stable-diffusion-1.5/square_int8/config.json
++      # Note, the following section installs Intel graphics packages in an attempt to
++      # enable the Intel GPU in the plugin. It did not work but I will keep this here
++      # as a starting point for adding GPU support in the future.
++      mkdir -p neo
++      cd neo
++      wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.17537.20/intel-igc-core_1.0.17537.20_amd64.deb
++      wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.17537.20/intel-igc-opencl_1.0.17537.20_amd64.deb
++      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/intel-level-zero-gpu-dbgsym_1.3.30872.22_amd64.ddeb
++      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/intel-level-zero-gpu-legacy1-dbgsym_1.3.30872.22_amd64.ddeb
++      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/intel-level-zero-gpu-legacy1_1.3.30872.22_amd64.deb
++      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/intel-level-zero-gpu_1.3.30872.22_amd64.deb
++      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/intel-opencl-icd-dbgsym_24.35.30872.22_amd64.ddeb
++      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/intel-opencl-icd-legacy1-dbgsym_24.35.30872.22_amd64.ddeb
++      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/intel-opencl-icd-legacy1_24.35.30872.22_amd64.deb
++      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/intel-opencl-icd_24.35.30872.22_amd64.deb
++      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/libigdgmm12_22.5.0_amd64.deb
++      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/ww35.sum
++      sha256sum -c ww35.sum
++      dpkg --root=$CRAFT_PART_INSTALL --force-all -i *.deb
++      craftctl default
++    override-stage: |
++      echo '{"python_path": "/usr/bin/python3", "weight_path": "/snap/gimp/current/weights", "supported_devices": ["CPU", "NPU", "GPU"]}' > $CRAFT_PART_INSTALL/usr/lib/x86_64-linux-gnu/gimp/2.99/plug-ins/openvino_utils/tools/gimp_openvino_config.json
++      craftctl default
++

--- a/snaps/gimp/snap/snapcraft.yaml
+++ b/snaps/gimp/snap/snapcraft.yaml
@@ -1,0 +1,306 @@
+name: gimp
+version: 2.99.19-dev
+summary: GNU Image Manipulation Program
+description: |
+  Whether you are a graphic designer, photographer, illustrator, or scientist,
+  GIMP provides you with sophisticated tools to get your job done. You can
+  further enhance your productivity with GIMP thanks to many customization
+  options and 3rd party plugins.
+
+grade: stable
+confinement: strict
+base: core24
+compression: lzo
+
+platforms:
+  amd64:
+
+layout:
+  /etc/gimp:
+    bind: $SNAP/etc/gimp
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/babl-0.1:
+    bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/babl-0.1
+  /usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gegl-0.4:
+    bind: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gegl-0.4
+  /usr/share/locale:
+    bind: $SNAP/usr/share/locale
+
+slots:
+  dbus-gimp:
+    interface: dbus
+    bus: session
+    name: org.gimp.GIMP.UI
+
+plugs:
+  intel-npu:
+    interface: custom-device
+    custom-device: intel-npu-device
+  npu-libs:
+    interface: content
+    content: npu-libs-2404
+    target: $SNAP/usr/lib/npu-libs-2404
+    #default-provider: intel-npu-driver # must be in latest/stable channel so commenting for now
+  process-control:
+    interface: process-control
+
+environment:
+  GI_TYPELIB_PATH: $SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gjs/girepository-1.0:$GI_TYPELIB_PATH
+  LD_LIBRARY_PATH: $SNAP/lib:$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/gnome-platform/usr/lib:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas:$SNAP/usr/lib/npu-libs-2404:$SNAP/usr/local/lib
+  # Ensure the gmic plugin can correctly locate the QT plugins
+  QT_PLUGIN_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/qt6/plugins
+  PYTHONPATH: $SNAP/gnome-platform/usr/lib/python3.12:$SNAP/gimpenv3/lib/python3.12/site-packages:$PYTHONPATH
+
+apps:
+  gimp:
+    command: usr/bin/gimp-2.99
+    extensions: [gnome]
+    desktop: usr/share/applications/gimp.desktop
+    common-id: org.gimp.GIMP
+    slots:
+      - dbus-gimp
+    plugs:
+      - cups-control
+      - browser-support
+      - home
+      - network
+      - removable-media
+      - unity7
+      - intel-npu
+      - npu-libs
+      - process-control
+
+parts:
+  babl:
+    plugin: meson
+    source: https://gitlab.gnome.org/GNOME/babl.git
+    # TODO: replace this with a tag on next release
+    #source-commit: c5f97c86224a473cc3fea231f17adef84580f2cc
+    source-tag: BABL_0_1_98
+    meson-parameters:
+      - --prefix=/usr
+      - --buildtype=release
+      - -Dwith-docs=false
+    build-packages:
+      - w3m
+
+  gegl:
+    after:
+      - babl
+    source: https://gitlab.gnome.org/GNOME/gegl.git
+    # TODO: replace this with a tag on next release
+    #source-commit: d540df2ad27c06891271d96247f915073b042a3e
+    source-tag: GEGL_0_4_46
+    plugin: meson
+    meson-parameters:
+      - --prefix=/usr
+      - --buildtype=release
+      - -Ddocs=false
+      - -Dworkshop=true
+    build-packages:
+      - ffmpeg
+      - libexiv2-dev
+      - libfftw3-dev
+      - libgexiv2-2
+      - libglu1-mesa-dev
+      - liblensfun-dev
+      - libluajit-5.1-dev
+      - libmaxflow-dev
+      - libopenexr-dev
+      - libraw-dev
+      - libsdl2-dev
+      - libspiro-dev
+      - libsuitesparse-dev
+      - libv4l-dev
+      - libwebp-dev
+    stage-packages:
+      - ffmpeg
+      - libamd3
+      - libbtf2
+      - libcamd3
+      - libccolamd3
+      - libcholmod5
+      - libcolamd3
+      - libcxsparse4
+      - libexiv2-27
+      - libgexiv2-2
+      - libgraphblas7
+      - libklu2
+      - liblapack3
+      - libldl3
+      - liblensfun1
+      - libluajit-5.1-2
+      - libmaxflow0
+      - libopenexr-3-1-30
+      - libraw-bin
+      - librbio4
+      - libsdl2-2.0-0
+      - libspiro1
+      - libspqr4
+      - libumfpack6
+      - libv4l-0
+
+  gimp:
+    after:
+      - babl
+      - gegl
+    plugin: meson
+    source: https://gitlab.gnome.org/GNOME/gimp.git
+    #source-commit: a92388c433da868c5d84b14362f7a8151d287ad7
+    source-tag: GIMP_2_99_16
+    override-pull: |
+      # TODO: remove `craftctl default` and use this when 2.99.19 actually releases
+      #   tag="$(echo "GIMP_${SNAPCRAFT_PROJECT_VERSION}" | tr "." "_")"
+      #   git clone -b "$tag" https://gitlab.gnome.org/GNOME/gimp.git
+      craftctl default
+      sed -i 's|^Icon=.*|Icon=/usr/share/icons/hicolor/256x256/apps/gimp.png|' desktop/gimp.desktop.in.in
+    meson-parameters:
+      - --prefix=/usr
+      - --buildtype=release
+      - -Dgi-docgen=disabled
+      - -Dg-ir-doc=false
+      - -Dbuild-id=org.gimp.GIMP.snapcraft.preview
+      - -Dbug-report-url=https://github.com/snapcrafters/gimp/issues/
+      - -Dcheck-update=no
+      - -Denable-default-bin=enabled
+      - -Drelocatable-bundle=yes
+      - -Dlibunwind=true
+    override-stage: |
+      echo "python=/usr/bin/python3" >  $CRAFT_PART_INSTALL/usr/lib/x86_64-linux-gnu/gimp/2.99/interpreters/pygimp.interp
+      echo "python3=/usr/bin/python3" >>  $CRAFT_PART_INSTALL/usr/lib/x86_64-linux-gnu/gimp/2.99/interpreters/pygimp.interp
+      echo "/usr/bin/python=/usr/bin/python3" >>  $CRAFT_PART_INSTALL/usr/lib/x86_64-linux-gnu/gimp/2.99/interpreters/pygimp.interp
+      echo "/usr/bin/python3=/usr/bin/python3" >>  $CRAFT_PART_INSTALL/usr/lib/x86_64-linux-gnu/gimp/2.99/interpreters/pygimp.interp
+      echo ":Python:E::py::python3:" >>  $CRAFT_PART_INSTALL/usr/lib/x86_64-linux-gnu/gimp/2.99/interpreters/pygimp.interp
+      craftctl default
+    build-environment:
+      - BABL_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/babl-0.1
+      - GEGL_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gegl-0.4
+      - GI_TYPELIB_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/girepository-1.0:$GI_TYPELIB_PATH
+      - LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$CRAFT_STAGE/usr/lib:$CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR
+    build-packages:
+      - automake
+      - intltool
+      - iso-codes
+      - libaa1-dev
+      - libappstream-glib-dev
+      - libart-2.0-dev
+      - libbz2-dev
+      - libcairo-gobject2
+      - libexif-dev
+      - libexpat1-dev
+      - libfftw3-dev
+      - libgexiv2-2
+      - libgpm-dev
+      - libice-dev
+      - libluajit-5.1-dev
+      - liblzma-dev
+      - libmng-dev
+      - libmypaint-dev
+      - libopenexr-dev
+      - libslang2-dev
+      - libsm-dev
+      - libunwind-dev
+      - libwebp-dev
+      - libwmf-dev
+      - libxmu-dev
+      - libxpm-dev
+      - luajit
+      - poppler-data
+      - xdg-utils
+      - xsltproc
+    stage-packages:
+      - evince
+      - ghostscript
+      - iso-codes
+      - libaa1
+      - libappstream-glib8
+      - libart-2.0-2
+      - libbz2-1.0
+      - libexif12
+      - libfftw3-bin
+      - libgexiv2-dev
+      - libgpm2
+      - libheif1
+      - libluajit-5.1-2
+      - liblzma5
+      - libmng2
+      - libmypaint-1.5-1
+      - libmypaint-common
+      - libopenexr-3-1-30
+      - libslang2
+      - libsndio7.0
+      - libunwind8
+      - libwebp7
+      - libwebpdemux2
+      - libwebpmux3
+      - libwmf-0.2-7
+      - libxmu6
+      - libxpm4
+      - libxv1
+      - lua-lgi
+      - luajit
+      - mypaint-brushes
+      - mypaint-data
+      - poppler-data
+
+  openvino-plugin:
+    after: [gimp]
+    plugin: nil
+    source: https://github.com/intel/openvino-ai-plugins-gimp.git
+    source-tag: v2.99-R3.1
+    build-packages:
+      - rsync
+    stage-packages:
+      - ocl-icd-libopencl1
+      - wget
+    override-build: |
+      set -e
+      which python3
+      python3 --version
+      python3 -m pip install --break-system-packages --user virtualenv
+      chmod +x install.sh
+      echo "1 2 3 4 0" | ./install.sh --install_models
+      mkdir -p $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/
+      cp -r $HOME/.config/GIMP/2.99/plug-ins/* $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/
+      sed -i "/self.core.set_property({'CACHE_DIR': os.path.join(model, 'cache')})/d" $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/openvino_utils/tools/openvino_common/models_ov/stable_diffusion_engine.py
+      sed -i "/try_enable_npu_turbo(device, self.core)/d" $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/openvino_utils/tools/openvino_common/models_ov/stable_diffusion_engine.py
+      sed -i 's/if "NPU" in device:/if "STOP" in device:/g' $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/openvino_utils/tools/openvino_common/models_ov/stable_diffusion_engine.py
+      sed -i 's/sd_option_cache = os.path.join(weight_path, ".."/sd_option_cache = os.path.join("."/g' $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/stable_diffusion_ov/stable_diffusion_ov.py
+      sed -i 's/os.path.join(weight_path, "..", "gimp_openvino_run_sd.json"/os.path.join(".", "gimp_openvino_run_sd.json"/g' $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/openvino_utils/tools/stable_diffusion_ov_server.py
+      sed -i 's/file_new_for_path(os.path.join(weight_path, ".."/file_new_for_path(os.path.join("."/g' $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/stable_diffusion_ov/stable_diffusion_ov.py
+      sed -i 's/cv2.imwrite(os.path.join(weight_path, ".."/cv2.imwrite(os.path.join("."/g' $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/openvino_utils/tools/stable_diffusion_ov_server.py
+      sed -i 's/DeviceEnum(supported_modes)/DeviceEnum(["CPU", "Balanced", "NPU"])/g' $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/stable_diffusion_ov/stable_diffusion_ov.py
+      sed -i 's/Power Mode/Device/g' $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/stable_diffusion_ov/stable_diffusion_ov.py
+      mkdir -p $CRAFT_PART_BUILD/mms_tmp
+      rsync -a $CRAFT_PART_BUILD/mms_tmp $CRAFT_PART_INSTALL/.
+      rsync -a /root/parts/openvino-plugin/gimpenv3 $CRAFT_PART_INSTALL/.
+      rsync -a /root/openvino-ai-plugins-gimp/weights $CRAFT_PART_INSTALL/.
+      echo "{" > $CRAFT_PART_INSTALL/weights/stable-diffusion-ov/stable-diffusion-1.5/square_int8/config.json
+      echo '      "power modes supported": "yes",' >> $CRAFT_PART_INSTALL/weights/stable-diffusion-ov/stable-diffusion-1.5/square_int8/config.json
+      echo '      "npu": ["NPU","NPU","NPU","NPU"],' >> $CRAFT_PART_INSTALL/weights/stable-diffusion-ov/stable-diffusion-1.5/square_int8/config.json
+      echo '      "balanced": ["NPU","CPU","NPU","NPU"],' >> $CRAFT_PART_INSTALL/weights/stable-diffusion-ov/stable-diffusion-1.5/square_int8/config.json
+      echo '      "cpu": ["CPU","CPU","CPU","CPU"]' >> $CRAFT_PART_INSTALL/weights/stable-diffusion-ov/stable-diffusion-1.5/square_int8/config.json
+      echo "}" >> $CRAFT_PART_INSTALL/weights/stable-diffusion-ov/stable-diffusion-1.5/square_int8/config.json
+      # Note, the following section installs Intel graphics packages in an attempt to
+      # enable the Intel GPU in the plugin. It did not work but I will keep this here
+      # as a starting point for adding GPU support in the future.
+      mkdir -p neo
+      cd neo
+      wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.17537.20/intel-igc-core_1.0.17537.20_amd64.deb
+      wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.17537.20/intel-igc-opencl_1.0.17537.20_amd64.deb
+      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/intel-level-zero-gpu-dbgsym_1.3.30872.22_amd64.ddeb
+      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/intel-level-zero-gpu-legacy1-dbgsym_1.3.30872.22_amd64.ddeb
+      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/intel-level-zero-gpu-legacy1_1.3.30872.22_amd64.deb
+      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/intel-level-zero-gpu_1.3.30872.22_amd64.deb
+      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/intel-opencl-icd-dbgsym_24.35.30872.22_amd64.ddeb
+      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/intel-opencl-icd-legacy1-dbgsym_24.35.30872.22_amd64.ddeb
+      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/intel-opencl-icd-legacy1_24.35.30872.22_amd64.deb
+      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/intel-opencl-icd_24.35.30872.22_amd64.deb
+      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/libigdgmm12_22.5.0_amd64.deb
+      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/ww35.sum
+      sha256sum -c ww35.sum
+      dpkg --root=$CRAFT_PART_INSTALL --force-all -i *.deb
+      craftctl default
+    override-stage: |
+      echo '{"python_path": "/usr/bin/python3", "weight_path": "/snap/gimp/current/weights", "supported_devices": ["CPU", "NPU", "GPU"]}' > $CRAFT_PART_INSTALL/usr/lib/x86_64-linux-gnu/gimp/2.99/plug-ins/openvino_utils/tools/gimp_openvino_config.json
+      craftctl default
+


### PR DESCRIPTION
Internal Jira task: [PEK-1298](https://warthogs.atlassian.net/browse/PEK-1298)

Relevant notes:
* This adds the `snapcraft.yaml` to get the OpenVINO stable diffusion plugin running on the NPU with the GIMP snap. Note that the `snapcraft.yaml` from the [`preview` branch of the GIMP snap GitHub repo](https://github.com/snapcrafters/gimp/tree/preview) was used as a starting place as it was recently updated to run on `core24`. I'm also including the patch file (by running `git diff`) in this commit for reference, but I'll paste it below in this PR description for convenience.
* Not all of the additions to the snap are intended to be permanent. I took some short cuts for the demo but want to save this work for reference in future work (when we're doing the real packaging).
* I remove the `gmic` part purely to speed up the build, that should be re-added in the future.
* The instructions for installing the plugin upstream can be [found here](https://github.com/intel/openvino-ai-plugins-gimp/blob/main/Docs/linux_install_guide.md). I installed dependencies from the git tags suggested in this install guide.

```diff
diff --git a/snap/snapcraft.yaml b/snap/snapcraft.yaml
index 7a7d07f..a2819cd 100755
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,7 +13,6 @@ base: core24
 compression: lzo
 
 platforms:
-  arm64:
   amd64:
 
 layout:
@@ -32,18 +31,30 @@ slots:
     bus: session
     name: org.gimp.GIMP.UI
 
+plugs:
+  intel-npu:
+    interface: custom-device
+    custom-device: intel-npu-device
+  npu-libs:
+    interface: content
+    content: npu-libs-2404
+    target: $SNAP/usr/lib/npu-libs-2404
+    #default-provider: intel-npu-driver # must be in latest/stable channel so commenting for now
+  process-control:
+    interface: process-control
+
 environment:
   GI_TYPELIB_PATH: $SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gjs/girepository-1.0:$GI_TYPELIB_PATH
-  LD_LIBRARY_PATH: $SNAP/lib:$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas
+  LD_LIBRARY_PATH: $SNAP/lib:$SNAP/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/gnome-platform/usr/lib:$SNAP/gnome-platform/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/lapack:$SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/blas:$SNAP/usr/lib/npu-libs-2404:$SNAP/usr/local/lib
   # Ensure the gmic plugin can correctly locate the QT plugins
   QT_PLUGIN_PATH: $SNAP/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/qt6/plugins
+  PYTHONPATH: $SNAP/gnome-platform/usr/lib/python3.12:$SNAP/gimpenv3/lib/python3.12/site-packages:$PYTHONPATH
 
 apps:
   gimp:
     command: usr/bin/gimp-2.99
     extensions: [gnome]
     desktop: usr/share/applications/gimp.desktop
-
     common-id: org.gimp.GIMP
     slots:
       - dbus-gimp
@@ -54,13 +65,17 @@ apps:
       - network
       - removable-media
       - unity7
+      - intel-npu
+      - npu-libs
+      - process-control
 
 parts:
   babl:
     plugin: meson
     source: https://gitlab.gnome.org/GNOME/babl.git
     # TODO: replace this with a tag on next release
-    source-commit: c5f97c86224a473cc3fea231f17adef84580f2cc
+    #source-commit: c5f97c86224a473cc3fea231f17adef84580f2cc
+    source-tag: BABL_0_1_98
     meson-parameters:
       - --prefix=/usr
       - --buildtype=release
@@ -73,7 +88,8 @@ parts:
       - babl
     source: https://gitlab.gnome.org/GNOME/gegl.git
     # TODO: replace this with a tag on next release
-    source-commit: d540df2ad27c06891271d96247f915073b042a3e
+    #source-commit: d540df2ad27c06891271d96247f915073b042a3e
+    source-tag: GEGL_0_4_46
     plugin: meson
     meson-parameters:
       - --prefix=/usr
@@ -129,7 +145,8 @@ parts:
       - gegl
     plugin: meson
     source: https://gitlab.gnome.org/GNOME/gimp.git
-    source-commit: a92388c433da868c5d84b14362f7a8151d287ad7
+    #source-commit: a92388c433da868c5d84b14362f7a8151d287ad7
+    source-tag: GIMP_2_99_16
     override-pull: |
       # TODO: remove `craftctl default` and use this when 2.99.19 actually releases
       #   tag="$(echo "GIMP_${SNAPCRAFT_PROJECT_VERSION}" | tr "." "_")"
@@ -147,6 +164,13 @@ parts:
       - -Denable-default-bin=enabled
       - -Drelocatable-bundle=yes
       - -Dlibunwind=true
+    override-stage: |
+      echo "python=/usr/bin/python3" >  $CRAFT_PART_INSTALL/usr/lib/x86_64-linux-gnu/gimp/2.99/interpreters/pygimp.interp
+      echo "python3=/usr/bin/python3" >>  $CRAFT_PART_INSTALL/usr/lib/x86_64-linux-gnu/gimp/2.99/interpreters/pygimp.interp
+      echo "/usr/bin/python=/usr/bin/python3" >>  $CRAFT_PART_INSTALL/usr/lib/x86_64-linux-gnu/gimp/2.99/interpreters/pygimp.interp
+      echo "/usr/bin/python3=/usr/bin/python3" >>  $CRAFT_PART_INSTALL/usr/lib/x86_64-linux-gnu/gimp/2.99/interpreters/pygimp.interp
+      echo ":Python:E::py::python3:" >>  $CRAFT_PART_INSTALL/usr/lib/x86_64-linux-gnu/gimp/2.99/interpreters/pygimp.interp
+      craftctl default
     build-environment:
       - BABL_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/babl-0.1
       - GEGL_PATH: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gegl-0.4
@@ -218,54 +242,68 @@ parts:
       - mypaint-data
       - poppler-data
 
-  gmic:
+  openvino-plugin:
     after: [gimp]
     plugin: nil
-    override-pull: |
-      VERSION=v.3.4.2
-      git clone -b "$VERSION" https://github.com/GreycLab/gmic.git
-      git clone -b "$VERSION" https://github.com/GreycLab/CImg.git
-      git clone -b "$VERSION" https://github.com/c-koi/gmic-qt.git
-
-      # Force this extra online fetch to happen during the pull phase.
-      # This build takes a long time on Launchpad, and if we wait until
-      # the build phase, by the time we get there the proxy token has
-      # expired - so force it to happen here.
-      wget -qO gmic/src/gmic_stdlib_community.h "https://gmic.eu/gmic_stdlib_community$(echo "${VERSION}" | tr -d "v.").h"
-    build-environment:
-      - QT_SELECT: qt6
+    source: https://github.com/intel/openvino-ai-plugins-gimp.git
+    source-tag: v2.99-R3.1
+    #build-environment:
+    #  - PATH: /snap/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+    #  - PYTHONPATH: ""
     build-packages:
-      - pkg-config
-      - qmake6-bin
-      - qt6-base-dev
-      - qt6-l10n-tools
-      - qt6-tools-dev
-      - qt6-wayland-dev
-      - qtchooser
-      - wget
+      - rsync
     stage-packages:
-      - libcurl4
-      - libdouble-conversion3
-      - libfftw3-bin
-      - libffi8
-      - libgraphicsmagick-q16-3
-      - libgraphicsmagick++-q16-12
-      - libjpeg-turbo8
-      - libopencv-core406t64
-      - libopencv-highgui406t64
-      - libopencv-video406t64
-      - libopenexr-3-1-30
-      - libpng16-16
-      - libqt6core6t64
-      - libqt6gui6t64
-      - libqt6network6t64
-      - libqt6widgets6t64
-      - qt6-wayland
+      - ocl-icd-libopencl1
+      - wget
     override-build: |
-      qtchooser -install qt6 "$(which qmake6)" || true
-      make -C gmic/src CImg.h gmic_stdlib_community.h
-      cd gmic-qt
-      qmake HOST=gimp3
-      make
-      install -Dm 0755 $CRAFT_PART_BUILD/gmic-qt/gmic_gimp_qt \
-        $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/3.0/plug-ins/gmic_gimp_qt/gmic_gimp_qt
+      set -e
+      which python3
+      python3 --version
+      python3 -m pip install --break-system-packages --user virtualenv
+      chmod +x install.sh
+      echo "1 2 3 4 0" | ./install.sh --install_models
+      mkdir -p $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/
+      cp -r $HOME/.config/GIMP/2.99/plug-ins/* $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/
+      sed -i "/self.core.set_property({'CACHE_DIR': os.path.join(model, 'cache')})/d" $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/openvino_utils/tools/openvino_common/models_ov/stable_diffusion_engine.py
+      sed -i "/try_enable_npu_turbo(device, self.core)/d" $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/openvino_utils/tools/openvino_common/models_ov/stable_diffusion_engine.py
+      sed -i 's/if "NPU" in device:/if "STOP" in device:/g' $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/openvino_utils/tools/openvino_common/models_ov/stable_diffusion_engine.py
+      sed -i 's/sd_option_cache = os.path.join(weight_path, ".."/sd_option_cache = os.path.join("."/g' $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/stable_diffusion_ov/stable_diffusion_ov.py
+      sed -i 's/os.path.join(weight_path, "..", "gimp_openvino_run_sd.json"/os.path.join(".", "gimp_openvino_run_sd.json"/g' $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/openvino_utils/tools/stable_diffusion_ov_server.py
+      sed -i 's/file_new_for_path(os.path.join(weight_path, ".."/file_new_for_path(os.path.join("."/g' $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/stable_diffusion_ov/stable_diffusion_ov.py
+      sed -i 's/cv2.imwrite(os.path.join(weight_path, ".."/cv2.imwrite(os.path.join("."/g' $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/openvino_utils/tools/stable_diffusion_ov_server.py
+      sed -i 's/DeviceEnum(supported_modes)/DeviceEnum(["CPU", "Balanced", "NPU"])/g' $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/stable_diffusion_ov/stable_diffusion_ov.py
+      sed -i 's/Power Mode/Device/g' $CRAFT_PART_INSTALL/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/gimp/2.99/plug-ins/stable_diffusion_ov/stable_diffusion_ov.py
+      mkdir -p $CRAFT_PART_BUILD/mms_tmp
+      rsync -a $CRAFT_PART_BUILD/mms_tmp $CRAFT_PART_INSTALL/.
+      rsync -a /root/parts/openvino-plugin/gimpenv3 $CRAFT_PART_INSTALL/.
+      rsync -a /root/openvino-ai-plugins-gimp/weights $CRAFT_PART_INSTALL/.
+      echo "{" > $CRAFT_PART_INSTALL/weights/stable-diffusion-ov/stable-diffusion-1.5/square_int8/config.json
+      echo '      "power modes supported": "yes",' >> $CRAFT_PART_INSTALL/weights/stable-diffusion-ov/stable-diffusion-1.5/square_int8/config.json
+      echo '      "npu": ["NPU","NPU","NPU","NPU"],' >> $CRAFT_PART_INSTALL/weights/stable-diffusion-ov/stable-diffusion-1.5/square_int8/config.json
+      echo '      "balanced": ["NPU","CPU","NPU","NPU"],' >> $CRAFT_PART_INSTALL/weights/stable-diffusion-ov/stable-diffusion-1.5/square_int8/config.json
+      echo '      "cpu": ["CPU","CPU","CPU","CPU"]' >> $CRAFT_PART_INSTALL/weights/stable-diffusion-ov/stable-diffusion-1.5/square_int8/config.json
+      echo "}" >> $CRAFT_PART_INSTALL/weights/stable-diffusion-ov/stable-diffusion-1.5/square_int8/config.json
+      # Note, the following section installs Intel graphics packages in an attempt to
+      # enable the Intel GPU in the plugin. It did not work but I will keep this here
+      # as a starting point for adding GPU support in the future.
+      mkdir -p neo
+      cd neo
+      wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.17537.20/intel-igc-core_1.0.17537.20_amd64.deb
+      wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.17537.20/intel-igc-opencl_1.0.17537.20_amd64.deb
+      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/intel-level-zero-gpu-dbgsym_1.3.30872.22_amd64.ddeb
+      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/intel-level-zero-gpu-legacy1-dbgsym_1.3.30872.22_amd64.ddeb
+      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/intel-level-zero-gpu-legacy1_1.3.30872.22_amd64.deb
+      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/intel-level-zero-gpu_1.3.30872.22_amd64.deb
+      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/intel-opencl-icd-dbgsym_24.35.30872.22_amd64.ddeb
+      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/intel-opencl-icd-legacy1-dbgsym_24.35.30872.22_amd64.ddeb
+      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/intel-opencl-icd-legacy1_24.35.30872.22_amd64.deb
+      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/intel-opencl-icd_24.35.30872.22_amd64.deb
+      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/libigdgmm12_22.5.0_amd64.deb
+      wget https://github.com/intel/compute-runtime/releases/download/24.35.30872.22/ww35.sum
+      sha256sum -c ww35.sum
+      dpkg --root=$CRAFT_PART_INSTALL --force-all -i *.deb
+      craftctl default
+    override-stage: |
+      echo '{"python_path": "/usr/bin/python3", "weight_path": "/snap/gimp/current/weights", "supported_devices": ["CPU", "NPU", "GPU"]}' > $CRAFT_PART_INSTALL/usr/lib/x86_64-linux-gnu/gimp/2.99/plug-ins/openvino_utils/tools/gimp_openvino_config.json
+      craftctl default
+
```

[PEK-1298]: https://warthogs.atlassian.net/browse/PEK-1298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ