### PR TITLE
Integrate command-chain script for openvino snap

### DIFF
--- a/snaps/openvino/consumer-intel-npu-driver-and-openvino-toolkit-2404/README.md
+++ b/snaps/openvino/consumer-intel-npu-driver-and-openvino-toolkit-2404/README.md
@@ -23,17 +23,23 @@ sudo snap install --beta intel-npu-driver
 sudo snap install --dangerous ~/openvino-toolkit-2404_2024.4.0_amd64.snap
 ```
 
-Connect interfaces:
+Connect the following interfaces manually:
 
 ```
-sudo snap connect openvino-python:intel-npu intel-npu-driver:intel-npu
 sudo snap connect openvino-python:npu-libs intel-npu-driver:npu-libs
 sudo snap connect openvino-python:openvino-libs openvino-toolkit-2404:openvino-libs
-sudo snap connect openvino-python:opengl
-sudo snap connect openvino-python:home
-sudo snap connect openvino-python:network
-sudo snap connect openvino-python:network-bind
 sudo snap connect openvino-python:hugepages-control
+```
+
+The following interfaces should auto-connect:
+
+```bash
+$ snap connections | grep openvino
+custom-device            openvino-python:intel-npu        intel-npu-driver:intel-npu  -
+home                     openvino-python:home             :home                       -
+network                  openvino-python:network          :network                    -
+network-bind             openvino-python:network-bind     :network-bind               -
+opengl                   openvino-python:opengl           :opengl                     -
 ```
 
 ## Running apps

--- a/snaps/openvino/consumer-intel-npu-driver-and-openvino-toolkit-2404/snap/snapcraft.yaml
+++ b/snaps/openvino/consumer-intel-npu-driver-and-openvino-toolkit-2404/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: openvino-python
 base: core24
-version: '2024.4.0'
+version: '2024.5.0'
 summary: Snap for testing the OpenVINO Python API
 description: |
   OpenVINO is a software toolkit for optimizing and deploying deep learning models.
@@ -16,7 +16,7 @@ plugs:
   npu-libs:
     interface: content
     content: npu-libs-2404
-    target: $SNAP/usr/lib/npu-libs-2404
+    target: $SNAP/npu-libs
     #default-provider: intel-npu-driver # must be in latest/stable channel so commenting for now
   openvino-libs:
     interface: content
@@ -27,6 +27,7 @@ plugs:
 apps:
 
   ipython:
+    command-chain: [command-chain/openvino-launch]
     command: bin/ipython
     plugs:
       - intel-npu # NPU device
@@ -37,12 +38,11 @@ apps:
       - home
       - hugepages-control
     environment:
-      PYTHONPATH: $SNAP/usr/lib/python3/dist-packages:$SNAP/openvino/usr/python:$SNAP/openvino/usr/python/openvino/tools/ovc:$PYTHONPATH
-      LD_LIBRARY_PATH: $SNAP/openvino/usr/runtime/lib/intel64:$SNAP/openvino/usr/lib/x86_64-linux-gnu:$SNAP/usr/lib/npu-libs-2404:$SNAP/usr/local/lib:$LD_LIBRARY_PATH
-      PATH: $SNAP/openvino/usr/python/openvino/tools/ovc:$PATH
+      LD_LIBRARY_PATH: $SNAP/npu-libs:$SNAP/usr/local/lib:$LD_LIBRARY_PATH
       OCL_ICD_VENDORS: $SNAP/etc/OpenCL/vendors
 
   jupyter:
+    command-chain: [command-chain/openvino-launch]
     command: bin/jupyter
     plugs:
       - intel-npu # GPU device
@@ -54,9 +54,7 @@ apps:
       - network-bind # needed by jupyter
       - hugepages-control
     environment:
-      PYTHONPATH: $SNAP/usr/lib/python3/dist-packages:$SNAP/openvino/usr/python:$SNAP/openvino/usr/python/openvino/tools/ovc:$PYTHONPATH
-      LD_LIBRARY_PATH: $SNAP/openvino/usr/runtime/lib/intel64:$SNAP/openvino/usr/lib/x86_64-linux-gnu:$SNAP/usr/lib/npu-libs-2404:$SNAP/usr/local/lib:$LD_LIBRARY_PATH
-      PATH: $SNAP/openvino/usr/python/openvino/tools/ovc:$PATH
+      LD_LIBRARY_PATH: $SNAP/npu-libs:$SNAP/usr/local/lib:$LD_LIBRARY_PATH
       OCL_ICD_VENDORS: $SNAP/etc/OpenCL/vendors
 
 parts:
@@ -66,7 +64,7 @@ parts:
     # https://github.com/openvinotoolkit/openvino_notebooks/blob/latest/notebooks/gpu-device
     source-type: git
     source: https://github.com/openvinotoolkit/openvino.git
-    source-tag: 2024.4.0
+    source-tag: 2024.5.0
     plugin: python
     python-requirements: [src/bindings/python/requirements.txt]
     python-packages: [ipython, jupyterlab, ipywidgets, opencv-python, tqdm, huggingface_hub, matplotlib>=3.4]
@@ -131,6 +129,14 @@ parts:
         echo "${base_path}""${intel_legacy1_icd_so_path}" > "${intel_legacy1_icd}"
       fi
       craftctl default
+  command-chain:
+    plugin: dump
+    source-type: git
+    source: https://github.com/canonical/openvino-toolkit-snap.git
+    #source-branch: openvino-toolkit-2404
+    source-branch: frenchwr/command-chain # temporary for testing
+    stage:
+      - command-chain/openvino-launch
 
 lint:
   ignore:

--- a/snaps/openvino/consumer-intel-npu-driver-and-openvino-toolkit-2404/snap/snapcraft.yaml
+++ b/snaps/openvino/consumer-intel-npu-driver-and-openvino-toolkit-2404/snap/snapcraft.yaml
@@ -112,9 +112,7 @@ parts:
       # https://docs.openvino.ai/2024/get-started/configurations/configurations-intel-gpu.html
       wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.17791.9/intel-igc-core_1.0.17791.9_amd64.deb
       wget https://github.com/intel/intel-graphics-compiler/releases/download/igc-1.0.17791.9/intel-igc-opencl_1.0.17791.9_amd64.deb
-      wget https://github.com/intel/compute-runtime/releases/download/24.39.31294.12/intel-level-zero-gpu-dbgsym_1.6.31294.12_amd64.ddeb
       wget https://github.com/intel/compute-runtime/releases/download/24.39.31294.12/intel-level-zero-gpu_1.6.31294.12_amd64.deb
-      wget https://github.com/intel/compute-runtime/releases/download/24.39.31294.12/intel-opencl-icd-dbgsym_24.39.31294.12_amd64.ddeb
       wget https://github.com/intel/compute-runtime/releases/download/24.39.31294.12/intel-opencl-icd_24.39.31294.12_amd64.deb
       wget https://github.com/intel/compute-runtime/releases/download/24.39.31294.12/libigdgmm12_22.5.2_amd64.deb
       dpkg --root=$CRAFT_PART_INSTALL --force-all -i *.deb
@@ -133,8 +131,7 @@ parts:
     plugin: dump
     source-type: git
     source: https://github.com/canonical/openvino-toolkit-snap.git
-    #source-branch: openvino-toolkit-2404
-    source-branch: frenchwr/command-chain # temporary for testing
+    source-branch: openvino-toolkit-2404
     stage:
       - command-chain/openvino-launch
 


### PR DESCRIPTION
Internal Jira task: [PEK-1461](https://warthogs.atlassian.net/browse/PEK-1461)

This updates the latest OpenVINO reference snap to use the `command-chain` script provided by the `openvino-toolkit-2404` snap, reducing the complexity of the `environment` section of each application. 

More context around the `command-chain` script can be found in https://github.com/canonical/openvino-toolkit-snap/pull/3.

Note that the new `command-chain` part is currently pulling directly from GitHub but could be changed later to use some other method like `staged-snaps`. 

Next we aim to reduce the complexity of the `snapcraft.yaml` further by introducing an openvino snapcraft extension.

[PEK-1461]: https://warthogs.atlassian.net/browse/PEK-1461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ